### PR TITLE
change name: code interpreter only

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,29 +9,30 @@ The following table lists the parameters in the configuration file:
 
 
 
-| Parameter                                     | Description                                                                      | Default Value                                                                          |
-|-----------------------------------------------|----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| `llm.model`                                   | The model name used by the language model.                                       | gpt-4                                                                                  |
-| `llm.backup_model`                            | The model name used for self-correction purposes.                                | `null`                                                                                 |
-| `llm.api_base`                                | The base URL of the OpenAI API.                                                  | `https://api.openai.com/v1`                                                            |
-| `llm.api_key`                                 | The API key of the OpenAI API.                                                   | `null`                                                                                 |
-| `llm.api_type`                                | The type of the OpenAI API, could be `openai` or `azure`.                        | `openai`                                                                               |
-| `llm.api_version`                             | The version of the OpenAI API.                                                   | `2023-07-01-preview`                                                                   |
+| Parameter                                     | Description                                                                     | Default Value                                                                          |
+|-----------------------------------------------|---------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| `llm.model`                                   | The model name used by the language model.                                      | gpt-4                                                                                  |
+| `llm.backup_model`                            | The model name used for self-correction purposes.                               | `null`                                                                                 |
+| `llm.api_base`                                | The base URL of the OpenAI API.                                                 | `https://api.openai.com/v1`                                                            |
+| `llm.api_key`                                 | The API key of the OpenAI API.                                                  | `null`                                                                                 |
+| `llm.api_type`                                | The type of the OpenAI API, could be `openai` or `azure`.                       | `openai`                                                                               |
+| `llm.api_version`                             | The version of the OpenAI API.                                                  | `2023-07-01-preview`                                                                   |
 | `llm.response_format`                         | The response format of the OpenAI API, could be `json_object`, `text` or `null`. | `json_object`                                                                          |
-| `code_interpreter.code_verification_on`       | Whether to enable code verification.                                             | `false`                                                                                |
-| `code_interpreter.plugin_only`                | Whether to turn on the plugin only mode.                                         | `false`                                                                                |
-| `code_interpreter.allowed_modules`            | The list of allowed modules to import in code generation.                        | `"pandas", "matplotlib", "numpy", "sklearn", "scipy", "seaborn", "datetime", "typing"` |
-| `logging.log_file`                            | The name of the log file.                                                        | `taskweaver.log`                                                                       |
-| `logging.log_folder`                          | The folder to store the log file.                                                | `logs`                                                                                 |
-| `plugin.base_path`                            | The folder to store plugins.                                                     | `${AppBaseDir}/plugins`                                                                |
-| `planner.example_base_path`                   | The folder to store planner examples.                                            | `${AppBaseDir}/planner_examples`                                                       |
-| `planner.prompt_compression`                  | Whether to compress the chat history for planner                                 | `false`                                                                                | 
-| `code_generator.example_base_path`            | The folder to store code interpreter examples.                                   | `${AppBaseDir}/codeinterpreter_examples`                                               |
-| `code_generator.prompt_compression`           | Whether to compress the chat history for code interpreter                        | `false`                                                                                |
-| `code_generator.enable_auto_plugin_selection` | Whether to enable auto plugin selection                                          | `false`                                                                                |
-| `code_generator.auto_plugin_selection_topk`   | The number of auto selected plugins  in each round                               | `3`                                                                                    |
-| `session.max_internal_chat_round_num`         | The maximum number of internal chat rounds between Planner and Code Interpreter  | `10`                                                                                   |
-| `session.code_interpreter_only`               | Allow users to directly communicate with the Code Interpreter.                                | `false`                                                                                |
+| `code_interpreter.code_verification_on`       | Whether to enable code verification.                                            | `false`                                                                                |
+| `code_interpreter.plugin_only`                | Whether to turn on the plugin only mode.                                        | `false`                                                                                |
+| `code_interpreter.allowed_modules`            | The list of allowed modules to import in code generation.                       | `"pandas", "matplotlib", "numpy", "sklearn", "scipy", "seaborn", "datetime", "typing"` |
+| `logging.log_file`                            | The name of the log file.                                                       | `taskweaver.log`                                                                       |
+| `logging.log_folder`                          | The folder to store the log file.                                               | `logs`                                                                                 |
+| `plugin.base_path`                            | The folder to store plugins.                                                    | `${AppBaseDir}/plugins`                                                                |
+| `planner.example_base_path`                   | The folder to store planner examples.                                           | `${AppBaseDir}/planner_examples`                                                       |
+| `planner.prompt_compression`                  | Whether to compress the chat history for planner                                | `false`                                                                                | 
+| `planner.skip_planning`                       | Whether to skip LLM planning process and enable the default plan                | `false`                                    |                                                                                              
+| `code_generator.example_base_path`            | The folder to store code interpreter examples.                                  | `${AppBaseDir}/codeinterpreter_examples`                                               |
+| `code_generator.prompt_compression`           | Whether to compress the chat history for code interpreter                       | `false`                                                                                |
+| `code_generator.enable_auto_plugin_selection` | Whether to enable auto plugin selection                                         | `false`                                                                                |
+| `code_generator.auto_plugin_selection_topk`   | The number of auto selected plugins  in each round                              | `3`                                                                                    |
+| `session.max_internal_chat_round_num`         | The maximum number of internal chat rounds between Planner and Code Interpreter | `10`                                                                                   |
+| `session.code_interpreter_only`               | Allow users to directly communicate with the Code Interpreter.                  | `false`                                                                                |
 
 > 💡 ${AppBaseDir} is the project directory.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,30 +9,30 @@ The following table lists the parameters in the configuration file:
 
 
 
-| Parameter                                     | Description                                                                     | Default Value                                                                          |
-|-----------------------------------------------|---------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| `llm.model`                                   | The model name used by the language model.                                      | gpt-4                                                                                  |
-| `llm.backup_model`                            | The model name used for self-correction purposes.                               | `null`                                                                                 |
-| `llm.api_base`                                | The base URL of the OpenAI API.                                                 | `https://api.openai.com/v1`                                                            |
-| `llm.api_key`                                 | The API key of the OpenAI API.                                                  | `null`                                                                                 |
-| `llm.api_type`                                | The type of the OpenAI API, could be `openai` or `azure`.                       | `openai`                                                                               |
-| `llm.api_version`                             | The version of the OpenAI API.                                                  | `2023-07-01-preview`                                                                   |
+| Parameter                                     | Description                                                                      | Default Value                                                                          |
+|-----------------------------------------------|----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| `llm.model`                                   | The model name used by the language model.                                       | gpt-4                                                                                  |
+| `llm.backup_model`                            | The model name used for self-correction purposes.                                | `null`                                                                                 |
+| `llm.api_base`                                | The base URL of the OpenAI API.                                                  | `https://api.openai.com/v1`                                                            |
+| `llm.api_key`                                 | The API key of the OpenAI API.                                                   | `null`                                                                                 |
+| `llm.api_type`                                | The type of the OpenAI API, could be `openai` or `azure`.                        | `openai`                                                                               |
+| `llm.api_version`                             | The version of the OpenAI API.                                                   | `2023-07-01-preview`                                                                   |
 | `llm.response_format`                         | The response format of the OpenAI API, could be `json_object`, `text` or `null`. | `json_object`                                                                          |
-| `code_interpreter.code_verification_on`       | Whether to enable code verification.                                            | `false`                                                                                |
-| `code_interpreter.plugin_only`                | Whether to turn on the plugin only mode.                                        | `false`                                                                                |
-| `code_interpreter.allowed_modules`            | The list of allowed modules to import in code generation.                       | `"pandas", "matplotlib", "numpy", "sklearn", "scipy", "seaborn", "datetime", "typing"` |
-| `logging.log_file`                            | The name of the log file.                                                       | `taskweaver.log`                                                                       |
-| `logging.log_folder`                          | The folder to store the log file.                                               | `logs`                                                                                 |
-| `plugin.base_path`                            | The folder to store plugins.                                                    | `${AppBaseDir}/plugins`                                                                |
-| `planner.example_base_path`                   | The folder to store planner examples.                                           | `${AppBaseDir}/planner_examples`                                                       |
-| `planner.prompt_compression`                  | Whether to compress the chat history for planner                                | `false`                                                                                | 
-| `planner.skip_planning`                       | Whether to skip LLM planning process and enable the default plan                | `false`                                    |                                                                                              
-| `code_generator.example_base_path`            | The folder to store code interpreter examples.                                  | `${AppBaseDir}/codeinterpreter_examples`                                               |
-| `code_generator.prompt_compression`           | Whether to compress the chat history for code interpreter                       | `false`                                                                                |
-| `code_generator.enable_auto_plugin_selection` | Whether to enable auto plugin selection                                         | `false`                                                                                |
-| `code_generator.auto_plugin_selection_topk`   | The number of auto selected plugins  in each round                              | `3`                                                                                    |
-| `session.max_internal_chat_round_num`         | The maximum number of internal chat rounds between Planner and Code Interpreter | `10`                                                                                   |
-| `session.code_interpreter_only`               | Allow users to directly communicate with the Code Interpreter.                  | `false`                                                                                |
+| `code_interpreter.code_verification_on`       | Whether to enable code verification.                                             | `false`                                                                                |
+| `code_interpreter.plugin_only`                | Whether to turn on the plugin only mode.                                         | `false`                                                                                |
+| `code_interpreter.allowed_modules`            | The list of allowed modules to import in code generation.                        | `"pandas", "matplotlib", "numpy", "sklearn", "scipy", "seaborn", "datetime", "typing"` |
+| `logging.log_file`                            | The name of the log file.                                                        | `taskweaver.log`                                                                       |
+| `logging.log_folder`                          | The folder to store the log file.                                                | `logs`                                                                                 |
+| `plugin.base_path`                            | The folder to store plugins.                                                     | `${AppBaseDir}/plugins`                                                                |
+| `planner.example_base_path`                   | The folder to store planner examples.                                            | `${AppBaseDir}/planner_examples`                                                       |
+| `planner.prompt_compression`                  | Whether to compress the chat history for planner.                                | `false`                                                                                | 
+| `planner.skip_planning`                       | Whether to skip LLM planning process and enable the default plan                 | `false`                                                                                |
+| `code_generator.example_base_path`            | The folder to store code interpreter examples.                                   | `${AppBaseDir}/codeinterpreter_examples`                                               |
+| `code_generator.prompt_compression`           | Whether to compress the chat history for code interpreter.                       | `false`                                                                                |
+| `code_generator.enable_auto_plugin_selection` | Whether to enable auto plugin selection.                                         | `false`                                                                                |
+| `code_generator.auto_plugin_selection_topk`   | The number of auto selected plugins in each round.                               | `3`                                                                                    |
+| `session.max_internal_chat_round_num`         | The maximum number of internal chat rounds between Planner and Code Interpreter. | `10`                                                                                   |
+| `session.code_interpreter_only`               | Allow users to directly communicate with the Code Interpreter.                   | `false`                                                                                |
 
 > 💡 ${AppBaseDir} is the project directory.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ The following table lists the parameters in the configuration file:
 | `code_generator.enable_auto_plugin_selection` | Whether to enable auto plugin selection                                          | `false`                                                                                |
 | `code_generator.auto_plugin_selection_topk`   | The number of auto selected plugins  in each round                               | `3`                                                                                    |
 | `session.max_internal_chat_round_num`         | The maximum number of internal chat rounds between Planner and Code Interpreter  | `10`                                                                                   |
-| `session.use_planner`                         | Use Planner or only use Code Interpreter                                         | `true`                                                                                 |
+| `session.code_interpreter_only`               | Allow users to directly communicate with the Code Interpreter.                                | `false`                                                                                |
 
 > 💡 ${AppBaseDir} is the project directory.
 

--- a/taskweaver/session/session.py
+++ b/taskweaver/session/session.py
@@ -17,7 +17,7 @@ class AppSessionConfig(ModuleConfig):
     def _configure(self) -> None:
         self._set_name("session")
 
-        self.use_planner = self._get_bool("use_planner", True)
+        self.code_interpreter_only = self._get_bool("code_interpreter_only", False)
         self.max_internal_chat_round_num = self._get_int("max_internal_chat_round_num", 10)
 
 
@@ -120,7 +120,7 @@ class Session:
             return reply_post
 
         try:
-            if self.config.use_planner:
+            if not self.config.code_interpreter_only:
                 post = Post.create(message=message, send_from="User", send_to="Planner")
                 while True:
                     post = _send_message(post.send_to, post)


### PR DESCRIPTION
- change `use_planner `to `code_interpreter_only`
- add back `skip_planning` in config doc