### PR TITLE
enforce attachment type to known list

### DIFF
--- a/playground/UI/app.py
+++ b/playground/UI/app.py
@@ -1,15 +1,16 @@
-import chainlit as cl
-import sys
 import os
-
+import sys
 from typing import Dict
+
+import chainlit as cl
+
+from taskweaver.memory.attachment import AttachmentType
+
 repo_path = os.path.join(os.path.dirname(__file__), "../../")
 sys.path.append(repo_path)
-from taskweaver.memory.round import Round
-
-from taskweaver.session.session import Session
-
 from taskweaver.app.app import TaskWeaverApp
+from taskweaver.memory.round import Round
+from taskweaver.session.session import Session
 
 project_path = os.path.join(repo_path, "project")
 app = TaskWeaverApp(app_dir=project_path, use_local_uri=True)
@@ -41,23 +42,29 @@ async def main(message: cl.Message):
             continue
         elements = []
         for atta in post.attachment_list:
-            if atta.type in ["python", "execution_result"]:
+            if atta.type in [
+                AttachmentType.python,
+                AttachmentType.execution_result,
+            ]:
                 continue
-            elif atta.type == "artifact_paths":
+            elif atta.type == AttachmentType.artifact_paths:
                 artifact_paths = [item.replace("file://", "") for item in atta.content]
             else:
                 elements.append(
-                    cl.Text(name=atta.type, content=atta.content, display="inline")
+                    cl.Text(name=atta.type.value, content=atta.content.encode(), display="inline"),
                 )
         elements.append(
             cl.Text(
                 name=f"{post.send_from} -> {post.send_to}",
                 content=post.message,
                 display="inline",
-            )
+            ),
         )
         await cl.Message(
-            content="---", elements=elements, parent_id=id, author=post.send_from
+            content="---",
+            elements=elements,
+            parent_id=id,
+            author=post.send_from,
         ).send()
 
     if post.send_to == "User":

--- a/taskweaver/code_interpreter/code_interpreter.py
+++ b/taskweaver/code_interpreter/code_interpreter.py
@@ -10,6 +10,7 @@ from taskweaver.code_interpreter.code_verification import code_snippet_verificat
 from taskweaver.config.module_config import ModuleConfig
 from taskweaver.logging import TelemetryLogger
 from taskweaver.memory import Attachment, Memory, Post
+from taskweaver.memory.attachment import AttachmentType
 from taskweaver.role import Role
 
 
@@ -37,9 +38,9 @@ def update_verification(
     status: Literal["NONE", "INCORRECT", "CORRECT"] = "NONE",
     error: str = "No verification is done.",
 ):
-    response.add_attachment(Attachment.create("verification", status))
+    response.add_attachment(Attachment.create(AttachmentType.verification, status))
     response.add_attachment(
-        Attachment.create("code_error", error),
+        Attachment.create(AttachmentType.code_error, error),
     )
 
 
@@ -48,9 +49,9 @@ def update_execution(
     status: Literal["NONE", "SUCCESS", "FAILURE"] = "NONE",
     result: str = "No code is executed.",
 ):
-    response.add_attachment(Attachment.create("execution_status", status))
+    response.add_attachment(Attachment.create(AttachmentType.execution_status, status))
     response.add_attachment(
-        Attachment.create("execution_result", result),
+        Attachment.create(AttachmentType.execution_result, result),
     )
 
 
@@ -97,7 +98,7 @@ class CodeInterpreter(Role):
             event_handler("CodeInterpreter->Planner", response.message)
             return response
 
-        code = next((a for a in response.attachment_list if a.type == "python"), None)
+        code = next((a for a in response.attachment_list if a.type == AttachmentType.python), None)
 
         if code is None:
             # no code is generated is usually due to the failure of parsing the llm output
@@ -108,7 +109,7 @@ class CodeInterpreter(Role):
                 error_message = format_output_revision_message()
                 response.add_attachment(
                     Attachment.create(
-                        "revise_message",
+                        AttachmentType.revise_message,
                         error_message,
                     ),
                 )
@@ -147,7 +148,7 @@ class CodeInterpreter(Role):
             if self.retry_count < self.config.max_retry_count:
                 response.add_attachment(
                     Attachment.create(
-                        "revise_message",
+                        AttachmentType.revise_message,
                         format_code_correction_message(),
                     ),
                 )
@@ -191,7 +192,7 @@ class CodeInterpreter(Role):
         # add artifact paths
         response.add_attachment(
             Attachment.create(
-                "artifact_paths",
+                AttachmentType.artifact_paths,
                 [
                     get_artifact_uri(
                         execution_id=exec_result.execution_id,
@@ -219,7 +220,7 @@ class CodeInterpreter(Role):
         else:
             response.add_attachment(
                 Attachment.create(
-                    "revise_message",
+                    AttachmentType.revise_message,
                     format_code_revision_message(),
                 ),
             )

--- a/taskweaver/llm/mock.py
+++ b/taskweaver/llm/mock.py
@@ -56,7 +56,7 @@ class MockApiServiceConfig(LLMServiceConfig):
 
         # split the chat completion response into chunks and delay each chunk by this amount
         # if negative, return the whole response at once
-        self.playback_chunk_delay: float = self._get_float(
+        self.playback_delay: float = self._get_float(
             "playback_delay",
             0.05,
         )
@@ -318,8 +318,9 @@ class MockApiService(CompletionService, EmbeddingService):
         self,
         cached_value: ChatMessageType,
     ) -> Generator[ChatMessageType, None, None]:
-        if self.config.playback_chunk_delay < 0:
+        if self.config.playback_delay < 0:
             yield cached_value
+            return
 
         role: ChatMessageRoleType = cached_value["role"]  # type: ignore
         content = cached_value["content"]
@@ -329,4 +330,4 @@ class MockApiService(CompletionService, EmbeddingService):
             next_pos = min(cur_pos + chunk_size, len(content))
             yield format_chat_message(role, content[cur_pos:next_pos])
             cur_pos = next_pos
-            time.sleep(self.config.playback_chunk_delay)
+            time.sleep(self.config.playback_delay)

--- a/taskweaver/memory/post.py
+++ b/taskweaver/memory/post.py
@@ -4,7 +4,7 @@ import secrets
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from taskweaver.memory.attachment import Attachment
+from taskweaver.memory.attachment import Attachment, AttachmentType
 from taskweaver.memory.type_vars import RoleName
 from taskweaver.utils import create_id
 
@@ -30,14 +30,14 @@ class Post:
     send_from: RoleName
     send_to: RoleName
     message: str
-    attachment_list: List[Attachment[Any]]
+    attachment_list: List[Attachment]
 
     @staticmethod
     def create(
         message: str,
         send_from: RoleName,
         send_to: RoleName,
-        attachment_list: Optional[List[Attachment[Any]]] = None,
+        attachment_list: Optional[List[Attachment]] = None,
     ) -> Post:
         """create a post with the given message, send_from, send_to, and attachment_list."""
         return Post(
@@ -83,14 +83,14 @@ class Post:
             else [],
         )
 
-    def add_attachment(self, attachment: Attachment[Any]) -> None:
+    def add_attachment(self, attachment: Attachment) -> None:
         """Add an attachment to the post."""
         self.attachment_list.append(attachment)
 
-    def get_attachment(self, type: str) -> List[Any]:
+    def get_attachment(self, type: AttachmentType) -> List[Any]:
         """Get all the attachments of the given type."""
         return [attachment.content for attachment in self.attachment_list if attachment.type == type]
 
-    def del_attachment(self, type_list: List[str]) -> None:
+    def del_attachment(self, type_list: List[AttachmentType]) -> None:
         """Delete all the attachments of the given type."""
         self.attachment_list = [attachment for attachment in self.attachment_list if attachment.type not in type_list]

--- a/taskweaver/planner/planner.py
+++ b/taskweaver/planner/planner.py
@@ -10,6 +10,7 @@ from taskweaver.llm import LLMApi
 from taskweaver.llm.util import ChatMessageType, format_chat_message
 from taskweaver.logging import TelemetryLogger
 from taskweaver.memory import Attachment, Conversation, Memory, Post, Round, RoundCompressor
+from taskweaver.memory.attachment import AttachmentType
 from taskweaver.memory.plugin import PluginRegistry
 from taskweaver.misc.example import load_examples
 from taskweaver.role import PostTranslator, Role
@@ -202,9 +203,11 @@ class Planner(Role):
             assert post.send_to is not None, "send_to field is None"
             assert post.send_to != "Planner", "send_to field should not be Planner"
             assert post.message is not None, "message field is None"
-            assert post.attachment_list[0].type == "init_plan", "attachment type is not init_plan"
-            assert post.attachment_list[1].type == "plan", "attachment type is not plan"
-            assert post.attachment_list[2].type == "current_plan_step", "attachment type is not current_plan_step"
+            assert post.attachment_list[0].type == AttachmentType.init_plan, "attachment type is not init_plan"
+            assert post.attachment_list[1].type == AttachmentType.plan, "attachment type is not plan"
+            assert (
+                post.attachment_list[2].type == AttachmentType.current_plan_step
+            ), "attachment type is not current_plan_step"
 
         if self.config.skip_planning and rounds[-1].post_list[-1].send_from == "User":
             self.config.dummy_plan["response"][0]["content"] += rounds[-1].post_list[-1].message
@@ -229,7 +232,7 @@ class Planner(Role):
                 "Please try to regenerate the output.",
                 send_to="Planner",
                 send_from="Planner",
-                attachment_list=[Attachment.create(type="invalid_response", content=llm_output)],
+                attachment_list=[Attachment.create(type=AttachmentType.invalid_response, content=llm_output)],
             )
             self.ask_self_cnt += 1
             if self.ask_self_cnt > self.max_self_ask_num:  # if ask self too many times, return error message

--- a/taskweaver/role/translator.py
+++ b/taskweaver/role/translator.py
@@ -2,13 +2,14 @@ import io
 import itertools
 import json
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Union
 
 import ijson
 from injector import inject
 
 from taskweaver.logging import TelemetryLogger
 from taskweaver.memory import Attachment, Post
+from taskweaver.memory.attachment import AttachmentType
 
 
 class PostTranslator:
@@ -28,9 +29,9 @@ class PostTranslator:
         self,
         llm_output: str,
         send_from: str,
-        event_handler: Callable,
-        early_stop: Optional[Callable] = None,
-        validation_func: Optional[Callable] = None,
+        event_handler: Callable[[str, str], None],
+        early_stop: Optional[Callable[[Union[AttachmentType, Literal["message", "send_to"]], str], bool]] = None,
+        validation_func: Optional[Callable[[Post], None]] = None,
     ) -> Post:
         """
         Convert the raw text output of LLM to a Post object.
@@ -45,17 +46,33 @@ class PostTranslator:
         post = Post.create(message=None, send_from=send_from, send_to=None)
         self.logger.info(f"LLM output: {llm_output}")
         for d in self.parse_llm_output_stream([llm_output]):
-            type = d["type"]
+            type_str = d["type"]
+            type: Optional[AttachmentType] = None
             value = d["content"]
-            if type == "message":
+            if type_str == "message":
                 post.message = value
-            elif type == "send_to":
-                post.send_to = value
+            elif type_str == "send_to":
+                assert value in [
+                    "User",
+                    "Planner",
+                    "CodeInterpreter",
+                ], f"Invalid send_to value: {value}"
+                post.send_to = value  # type: ignore
             else:
+                type = AttachmentType(type_str)
                 post.add_attachment(Attachment.create(type=type, content=value))
-            event_handler(type, value)
-
-            if early_stop is not None and early_stop(type, value):
+            event_handler(type_str, value)
+            parsed_type = (
+                type
+                if type is not None
+                else "message"
+                if type_str == "message"
+                else "send_to"
+                if type_str == "send_to"
+                else None
+            )
+            assert parsed_type is not None, f"Invalid type: {type_str}"
+            if early_stop is not None and early_stop(parsed_type, value):
                 break
 
         if post.send_to is not None:
@@ -68,10 +85,10 @@ class PostTranslator:
     def post_to_raw_text(
         self,
         post: Post,
-        content_formatter: Callable[[Attachment[Any]], str] = lambda x: x.content,
+        content_formatter: Callable[[Attachment], str] = lambda x: x.content,
         if_format_message: bool = True,
         if_format_send_to: bool = True,
-        ignore_types: Optional[List[str]] = None,
+        ignore_types: Optional[List[AttachmentType]] = None,
     ) -> str:
         """
         Convert a Post object to raw text in the format of LLM output.
@@ -82,35 +99,39 @@ class PostTranslator:
         :param ignore_types:
         :return: str
         """
-        structured_llm = []
+        structured_llm: List[Dict[str, str]] = []
         for attachment in post.attachment_list:
             attachments_dict = {}
             if ignore_types is not None and attachment.type in ignore_types:
                 continue
-            attachments_dict["type"] = attachment.type
+            attachments_dict["type"] = attachment.type.value
             attachments_dict["content"] = content_formatter(attachment)
             structured_llm.append(attachments_dict)
         if if_format_send_to:
             structured_llm.append({"type": "send_to", "content": post.send_to})
         if if_format_message:
             structured_llm.append({"type": "message", "content": post.message})
-        structured_llm = {"response": structured_llm}
-        structured_llm_text = json.dumps(structured_llm)
+        structured_llm_text = json.dumps({"response": structured_llm})
         return structured_llm_text
 
-    def parse_llm_output(self, llm_output: str) -> List[Dict]:
+    def parse_llm_output(self, llm_output: str) -> List[Dict[str, str]]:
         try:
-            structured_llm_output = json.loads(llm_output)["response"]
-            assert isinstance(structured_llm_output, list), "LLM output should be a list object"
-            return structured_llm_output
+            structured_llm_output: Any = json.loads(llm_output)["response"]
+            assert isinstance(
+                structured_llm_output,
+                list,
+            ), "LLM output should be a list object"
+            return structured_llm_output  # type: ignore
         except (JSONDecodeError, AssertionError) as e:
-            self.logger.error(f"Failed to parse LLM output due to {str(e)}. LLM output:\n {llm_output}")
+            self.logger.error(
+                f"Failed to parse LLM output due to {str(e)}. LLM output:\n {llm_output}",
+            )
             raise e
 
     def parse_llm_output_stream(
         self,
         llm_output: Iterator[str],
-    ) -> Iterator[Dict]:
+    ) -> Iterator[Dict[str, str]]:
         json_data_stream = io.StringIO("".join(itertools.chain(llm_output)))
         parser = ijson.parse(json_data_stream)
         element = {}
@@ -129,4 +150,6 @@ class PostTranslator:
                     yield element
                     element = {}
         except ijson.JSONError as e:
-            self.logger.warning(f"Failed to parse LLM output stream due to JSONError: {str(e)}")
+            self.logger.warning(
+                f"Failed to parse LLM output stream due to JSONError: {str(e)}",
+            )

--- a/tests/unit_tests/test_code_generator.py
+++ b/tests/unit_tests/test_code_generator.py
@@ -46,14 +46,19 @@ def test_compose_prompt():
         send_to="Planner",
         attachment_list=[],
     )
-    post2.add_attachment(Attachment.create("thought", "{ROLE_NAME} sees the user wants generate a DataFrame."))
+    post2.add_attachment(
+        Attachment.create(
+            "thought",
+            "{ROLE_NAME} sees the user wants generate a DataFrame.",
+        ),
+    )
     post2.add_attachment(
         Attachment.create(
             "thought",
             "{ROLE_NAME} sees all required Python libs have been imported, so will not generate import codes.",
         ),
     )
-    post2.add_attachment(Attachment.create("code", code1))
+    post2.add_attachment(Attachment.create("python", code1))
     post2.add_attachment(Attachment.create("execution_status", "SUCCESS"))
     post2.add_attachment(
         Attachment.create(
@@ -94,7 +99,7 @@ def test_compose_prompt():
     )
     post4.add_attachment(
         Attachment.create(
-            "code",
+            "python",
             (
                 "min_value = df['VALUE'].min()\n"
                 "max_value = df['VALUE'].max()\n"
@@ -160,7 +165,7 @@ def test_compose_prompt():
         '{"response": [{"type": "thought", "content": "ProgramApe sees the user wants '
         'generate a DataFrame."}, {"type": "thought", "content": "ProgramApe sees all '
         "required Python libs have been imported, so will not generate import "
-        'codes."}, {"type": "code", "content": "df = pd.DataFrame(np.random.rand(10, '
+        'codes."}, {"type": "python", "content": "df = pd.DataFrame(np.random.rand(10, '
         "2), columns=['DATE', 'VALUE'])\\ndescriptions = "
         '[(\\"sample_code_description\\", \\"Sample code has been generated to get a '
         "dataframe `df` \\nwith 10 rows and 2 columns: 'DATE' and 'VALUE'\\\")]\"}, "
@@ -198,7 +203,10 @@ def test_compose_prompt_with_plugin():
                 os.path.dirname(os.path.abspath(__file__)),
                 "data/prompts/generator_prompt.yaml",
             ),
-            "plugin.base_path": os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/plugins"),
+            "plugin.base_path": os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "data/plugins",
+            ),
         },
     )
     app_injector.binder.bind(AppConfigSource, to=app_config)
@@ -225,14 +233,19 @@ def test_compose_prompt_with_plugin():
         send_to="Planner",
         attachment_list=[],
     )
-    post2.add_attachment(Attachment.create("thought", "{ROLE_NAME} sees the user wants generate a DataFrame."))
+    post2.add_attachment(
+        Attachment.create(
+            "thought",
+            "{ROLE_NAME} sees the user wants generate a DataFrame.",
+        ),
+    )
     post2.add_attachment(
         Attachment.create(
             "thought",
             "{ROLE_NAME} sees all required Python libs have been imported, so will not generate import codes.",
         ),
     )
-    post2.add_attachment(Attachment.create("code", code1))
+    post2.add_attachment(Attachment.create("python", code1))
     post2.add_attachment(Attachment.create("execution_status", "SUCCESS"))
     post2.add_attachment(
         Attachment.create(
@@ -273,7 +286,10 @@ def test_compose_prompt_with_plugin_only():
                 os.path.dirname(os.path.abspath(__file__)),
                 "data/prompts/generator_prompt.yaml",
             ),
-            "plugin.base_path": os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/plugins"),
+            "plugin.base_path": os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "data/plugins",
+            ),
             "code_generator.example_base_path": os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "data/examples/codeinterpreter_examples",
@@ -287,12 +303,12 @@ def test_compose_prompt_with_plugin_only():
     from taskweaver.code_interpreter.code_generator import CodeGenerator
     from taskweaver.memory import Attachment, Memory, Post, Round
 
-    code_generator = app_injector.create_object(
-        CodeGenerator,
-        additional_kwargs={
-            "plugin_only": True,
-            "code_verification_on": True,
-        },
+    code_generator = app_injector.get(CodeGenerator)
+
+    code_generator.configure_verification(
+        code_verification_on=True,
+        plugin_only=True,
+        allowed_modules=[],
     )
 
     code1 = (
@@ -312,14 +328,19 @@ def test_compose_prompt_with_plugin_only():
         send_to="Planner",
         attachment_list=[],
     )
-    post2.add_attachment(Attachment.create("thought", "{ROLE_NAME} sees the user wants generate a DataFrame."))
+    post2.add_attachment(
+        Attachment.create(
+            "thought",
+            "{ROLE_NAME} sees the user wants generate a DataFrame.",
+        ),
+    )
     post2.add_attachment(
         Attachment.create(
             "thought",
             "{ROLE_NAME} sees all required Python libs have been imported, so will not generate import codes.",
         ),
     )
-    post2.add_attachment(Attachment.create("code", code1))
+    post2.add_attachment(Attachment.create("python", code1))
     post2.add_attachment(Attachment.create("execution_status", "SUCCESS"))
     post2.add_attachment(
         Attachment.create(
@@ -362,7 +383,10 @@ def test_compose_prompt_with_not_plugin_only():
                 os.path.dirname(os.path.abspath(__file__)),
                 "data/prompts/generator_prompt.yaml",
             ),
-            "plugin.base_path": os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/plugins"),
+            "plugin.base_path": os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "data/plugins",
+            ),
             "code_generator.example_base_path": os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "data/examples/codeinterpreter_examples",
@@ -395,14 +419,19 @@ def test_compose_prompt_with_not_plugin_only():
         send_to="Planner",
         attachment_list=[],
     )
-    post2.add_attachment(Attachment.create("thought", "{ROLE_NAME} sees the user wants generate a DataFrame."))
+    post2.add_attachment(
+        Attachment.create(
+            "thought",
+            "{ROLE_NAME} sees the user wants generate a DataFrame.",
+        ),
+    )
     post2.add_attachment(
         Attachment.create(
             "thought",
             "{ROLE_NAME} sees all required Python libs have been imported, so will not generate import codes.",
         ),
     )
-    post2.add_attachment(Attachment.create("code", code1))
+    post2.add_attachment(Attachment.create("python", code1))
     post2.add_attachment(Attachment.create("execution_status", "SUCCESS"))
     post2.add_attachment(
         Attachment.create(
@@ -478,14 +507,19 @@ def test_code_correction_prompt():
         send_to="CodeInterpreter",
         attachment_list=[],
     )
-    post2.add_attachment(Attachment.create("thought", "{ROLE_NAME} sees the user wants generate a DataFrame."))
+    post2.add_attachment(
+        Attachment.create(
+            "thought",
+            "{ROLE_NAME} sees the user wants generate a DataFrame.",
+        ),
+    )
     post2.add_attachment(
         Attachment.create(
             "thought",
             "{ROLE_NAME} sees all required Python libs have been imported, so will not generate import codes.",
         ),
     )
-    post2.add_attachment(Attachment.create("code", code1))
+    post2.add_attachment(Attachment.create("python", code1))
     post2.add_attachment(Attachment.create("execution_status", "FAILURE"))
     post2.add_attachment(
         Attachment.create(
@@ -493,7 +527,9 @@ def test_code_correction_prompt():
             "The code failed to execute. Please check the code and try again.",
         ),
     )
-    post2.add_attachment(Attachment.create("revise_message", "Please check the code and try again."))
+    post2.add_attachment(
+        Attachment.create("revise_message", "Please check the code and try again."),
+    )
 
     round1 = Round.create(user_query="hello", id="round-1")
     round1.add_post(post1)

--- a/tests/unit_tests/test_planner.py
+++ b/tests/unit_tests/test_planner.py
@@ -202,8 +202,13 @@ def test_skip_planning():
     memory = Memory(session_id="session-1")
     memory.conversation.add_round(round1)
 
-    response_post = planner.reply(memory, prompt_log_path=None, event_handler=None, use_back_up_engine=False)
+    response_post = planner.reply(
+        memory,
+        prompt_log_path=None,
+        event_handler=lambda *args: None,
+        use_back_up_engine=False,
+    )
 
-    assert response_post.message == "Please reply to the user's request: count the rows of /home/data.csv"
+    assert response_post.message == "Please process this request: count the rows of /home/data.csv"
     assert response_post.send_from == "Planner"
     assert response_post.send_to == "CodeInterpreter"


### PR DESCRIPTION
Use `enum` as type for attachment type to enforce checking. Will adopt each type in streaming and later processing. Some types of attachment might could be removed/combined later.