### PR TITLE
Hsl/fix image issue

### DIFF
--- a/playground/UI/app.py
+++ b/playground/UI/app.py
@@ -72,7 +72,7 @@ def file_display(files: List[Tuple[str, str]], session_cwd_path: str):
             image = cl.Image(
                 name=file_path,
                 display="inline",
-                path=file_path,
+                path=file_path if os.path.isabs(file_path) else os.path.join(session_cwd_path, file_path),
                 size="large",
             )
             elements.append(image)
@@ -383,7 +383,6 @@ async def main(message: cl.Message):
     session_cwd_path = session.execution_cwd
 
     # display loader before sending message
-
     async with cl.Step(name="", show_input=True, root=True) as root_step:
         response_round = await cl.make_async(session.send_message)(
             message.content,
@@ -393,7 +392,7 @@ async def main(message: cl.Message):
                     "path": element.path,
                 }
                 for element in message.elements
-                if element.type == "file"
+                if element.type == "file" or element.type == "image"
             ],
             event_handler=ChainLitMessageUpdater(root_step),
         )
@@ -432,7 +431,6 @@ async def main(message: cl.Message):
                 f"{img_prefix}[{file_name}]({file_path})",
                 file_name,
             )
-
         elements = file_display(files, session_cwd_path)
         await cl.Message(
             author="TaskWeaver",


### PR DESCRIPTION
Fix bug of "cannot upload image" since image is not File type.
Fix bug of display images generated not from the plot.show(), path is wrong.