### PR TITLE
:bug:: Fix merge conflict that was not corrected before merging PR

### DIFF
--- a/scripts/build_executor.sh
+++ b/scripts/build_executor.sh
@@ -22,14 +22,7 @@ else
 fi
 
 # Build the Docker image
-<<<<<<< HEAD:scripts/build_executor.sh
 docker build -t "$imageFullName" -f "$dockerfilePath" "$contextPath"
 
 # Tag the image
 docker tag "$imageFullName" "$imageName:latest"
-=======
-docker build -t "$imageName" -f "$dockerfilePath" "$contextPath"
-
-# Tag the image
-docker tag "$imageName" taskweavercontainers/taskweaver-executor:latest
->>>>>>> 99f1803e9fa8d55c5c739b42baf35a2021d92db1:scripts/build.sh


### PR DESCRIPTION
Fixed existing merge conflict that was not corrected on the previous PR and caused the `scripts/build_executor.sh` script to fail due to syntax error.